### PR TITLE
Add CoreML workflow for Apple silicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ In your Scrypted installation:
 1. Navigate to the detector plugin settings
 2. Enter this repository URL: `https://github.com/DMontgomery40/bird-classifier-google-aiy`
 3. Scrypted will automatically download the model and labels
+4. Alternatively, you can point Scrypted directly to the raw configuration file:
+   `https://raw.githubusercontent.com/DMontgomery40/bird-classifier-google-aiy/main/config.json`
 
 ## Model Details
 
@@ -26,7 +28,7 @@ In your Scrypted installation:
 
 ## Configuration
 
-The `config.json` file contains all necessary settings for Scrypted to use this classifier:
+The `config.json` file in the root of this repository contains all necessary settings for Scrypted to use this classifier:
 
 ```json
 {
@@ -53,6 +55,13 @@ The `config.json` file contains all necessary settings for Scrypted to use this 
 ## Alternative for North American Birds Only
 
 If you specifically need a classifier trained only on North American birds, consider using [npatta01/Bird-Classifier](https://github.com/npatta01/Bird-Classifier) which is trained on 400 North American bird species.
+
+## CoreML for Apple Silicon
+
+To build a CoreML version of this model, run `convert_to_coreml.py`.
+This downloads the TFLite model and outputs `aiy_birds.mlmodel`.
+Use `config_coreml.json` in Scrypted or host the generated model and update the `model.url` field.
+
 
 ## Credits
 

--- a/config_coreml.json
+++ b/config_coreml.json
@@ -1,0 +1,20 @@
+{
+  "name": "Google AIY Birds Classifier (CoreML)",
+  "version": "1.0.0",
+  "model": {
+    "url": "./aiy_birds.mlmodel",
+    "type": "coreml"
+  },
+  "labels": {
+    "url": "https://www.gstatic.com/aihub/tfhub/labelmaps/aiy_birds_V1_labelmap.csv",
+    "type": "csv"
+  },
+  "input": {
+    "width": 224,
+    "height": 224,
+    "channels": 3,
+    "mean": [127.5, 127.5, 127.5],
+    "std": [127.5, 127.5, 127.5]
+  }
+}
+

--- a/convert_to_coreml.py
+++ b/convert_to_coreml.py
@@ -1,0 +1,32 @@
+import argparse
+import urllib.request
+import coremltools as ct
+
+DEFAULT_URL = "https://storage.googleapis.com/tfhub-lite-models/google/lite-model/aiy/vision/classifier/birds_V1/3.tflite"
+
+
+def download_model(url, path):
+    print(f"Downloading {url} -> {path}")
+    urllib.request.urlretrieve(url, path)
+
+
+def convert(tflite_path, output_path):
+    print(f"Converting {tflite_path} to {output_path}")
+    mlmodel = ct.convert(tflite_path, source="tensorflow")
+    mlmodel.save(output_path)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Convert Google AIY Birds model to CoreML")
+    parser.add_argument("--tflite-url", default=DEFAULT_URL, help="URL of the TFLite model")
+    parser.add_argument("--output", default="aiy_birds.mlmodel", help="Output CoreML model filename")
+    args = parser.parse_args()
+
+    tflite_path = "model.tflite"
+    download_model(args.tflite_url, tflite_path)
+    convert(tflite_path, args.output)
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- add `convert_to_coreml.py` for converting the TFLite model to CoreML
- supply `config_coreml.json` template
- document the CoreML option in the README

## Testing
- `git status --short`
